### PR TITLE
Threading patch

### DIFF
--- a/modbus4mqtt.py
+++ b/modbus4mqtt.py
@@ -8,6 +8,7 @@ from collections import defaultdict, OrderedDict
 from ccorp.ruamel.yaml.include import YAML
 import click
 import paho.mqtt.client as mqtt
+import threading
 
 from . import modbus_interface
 version = "EW.0.81"
@@ -378,10 +379,12 @@ class mqtt_interface():
         return result
 
     def loop_forever(self):
+        pollthread = threading.Thread(target = self.poll, args = ())
         while True:
             # TODO this properly.
-            self.poll()
+            pollthread.start()
             sleep(self.config.get('update_rate', DEFAULT_SCAN_RATE_S))
+            pollthread.join()
 
     def singlerun(self):
             self.poll()

--- a/modbus4mqtt.py
+++ b/modbus4mqtt.py
@@ -379,9 +379,9 @@ class mqtt_interface():
         return result
 
     def loop_forever(self):
-        pollthread = threading.Thread(target = self.poll, args = ())
         while True:
             # TODO this properly.
+            pollthread = threading.Thread(target = self.poll, args = ())
             pollthread.start()
             sleep(self.config.get('update_rate', DEFAULT_SCAN_RATE_S))
             pollthread.join()

--- a/modbus4mqtt.py
+++ b/modbus4mqtt.py
@@ -11,7 +11,7 @@ import paho.mqtt.client as mqtt
 import threading
 
 from . import modbus_interface
-version = "EW.0.81"
+version = "EW.0.9"
 MAX_DECIMAL_POINTS = 3
 DEFAULT_SCAN_RATE_S = 5
 


### PR DESCRIPTION
the simple sleep delay now done after the poll is threaded.
the gap beetwen "update_rate" and real intervall is now ~0.003232 milliseconds depending on CPU-Speed.
more "realtime" is imposible without calling the poll-routine by a interupt-request done by HAL or a realtime microcontroller has to be used.
